### PR TITLE
Middleware wrapper support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    grac (2.1.0.pre.propermiddleware)
+    grac (2.2.0)
       typhoeus (~> 0.6.9)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    grac (2.1.0)
+    grac (2.1.0.pre.propermiddleware)
       typhoeus (~> 0.6.9)
 
 GEM

--- a/lib/grac/client.rb
+++ b/lib/grac/client.rb
@@ -19,7 +19,7 @@ module Grac
         :params         => options[:params]         || {},
         :headers        => { "User-Agent" => "Grac v#{Grac::VERSION}" }.merge(options[:headers] || {}),
         :postprocessing => options[:postprocessing] || {},
-        :middleware     => options[:middleware]    || []
+        :middleware     => options[:middleware]     || []
       }
       @options.freeze
       [:params, :headers, :postprocessing, :middleware].each do |k|
@@ -30,7 +30,7 @@ module Grac
 
     def set(options = {})
       options = options.merge({
-        headers:    @options[:headers].merge(options[:headers]      || {}),
+        headers:    @options[:headers].merge(options[:headers]    || {}),
         middleware: @options[:middleware] + (options[:middleware] || [])
       })
 
@@ -46,40 +46,19 @@ module Grac
 
     %w{post put patch}.each do |method|
       define_method method do |body = {}, params = {}|
-        request = build_request(method, { :body => body, :params => params })
-        run(request)
+        response = build_and_run(method, { :body => body, :params => params })
+        check_response(method, response)
       end
     end
 
     %w{get delete}.each do |method|
       define_method method do |params = {}|
-        request = build_request(method, { :params => params })
-        run(request)
+        response = build_and_run(method, { :params => params })
+        check_response(method, response)
       end
     end
 
     private
-      def build_request(method, options = {})
-        body   = options[:body].nil? || options[:body].empty? ? nil : options[:body].to_json
-        params = @options[:params].merge(options[:params] || {})
-
-        opts        = @options
-        request_uri = uri
-
-        @options[:middleware].each do |mw|
-          opts, request_uri, method, params, body = mw.call(opts, request_uri, method, params, body)
-        end
-
-        request_hash = { :method => method }
-        request_hash[:params]         = params
-        request_hash[:body]           = body
-        request_hash[:connecttimeout] = opts[:connecttimeout]
-        request_hash[:timeout]        = opts[:timeout]
-        request_hash[:headers]        = opts[:headers]
-
-        return ::Typhoeus::Request.new(request_uri, request_hash)
-      end
-
       def postprocessing(data, processing = nil)
         return data if @options[:postprocessing].nil? || @options[:postprocessing].empty?
 
@@ -105,11 +84,20 @@ module Grac
         return data
       end
 
-      def run(request)
+      def execute_request(opts, request_uri, method, params, body)
+        request_hash = {
+          :method         => method,
+          :params         => params,
+          :body           => body,
+          :connecttimeout => opts[:connecttimeout],
+          :timeout        => opts[:timeout],
+          :headers        => opts[:headers]
+        }
+
+        request  = ::Typhoeus::Request.new(request_uri, request_hash)
         response = request.run
 
         # Retry GET and HEAD requests - modifying requests might not be idempotent
-        method = request.options[:method].to_s.downcase
         response = request.run if response.timed_out? && ['get', 'head'].include?(method)
 
         # A request can time out while receiving data. In this case response.code might indicate
@@ -119,29 +107,56 @@ module Grac
           raise Exception::ServiceTimeout.new(method, request.url, response.return_message)
         end
 
-        grac_response = Response.new(response)
+        return Response.new(response)
+      end
+
+      def wrap_middleware(middleware, caller)
+        return lambda do |*params|
+          middleware.call(*params) do |*block_params|
+            caller.call(*block_params)
+          end
+        end
+      end
+
+      def wrapped_request
+        caller = lambda(&method(:execute_request))
+
+        @options[:middleware].reverse.each do |mw|
+          caller = wrap_middleware(mw, caller)
+        end
+
+        return caller
+      end
+
+      def build_and_run(method, options = {})
+        body   = options[:body].nil? || options[:body].empty? ? nil : options[:body].to_json
+        params = @options[:params].merge(options[:params] || {})
+        return wrapped_request.call(@options, uri, method, params, body)
+      end
+
+      def check_response(method, response)
         case response.code
           when 200..203, 206..299
             # unknown status codes must be treated as the x00 of their class, so 200
-            if grac_response.json_content?
-              return postprocessing(grac_response.parsed_json)
+            if response.json_content?
+              return postprocessing(response.parsed_json)
             end
 
-            return grac_response.body
+            return response.body
           when 204, 205
             return true
           when 0
-            raise Exception::RequestFailed.new(method, request.url, response.return_message)
+            raise Exception::RequestFailed.new(method, response.effective_url, response.return_message)
           when 400
-            raise Exception::BadRequest.new(method, request.url, grac_response.parsed_or_raw_body)
+            raise Exception::BadRequest.new(method, response.effective_url, response.parsed_or_raw_body)
           when 403
-            raise Exception::Forbidden.new(method, request.url, grac_response.parsed_or_raw_body)
+            raise Exception::Forbidden.new(method, response.effective_url, response.parsed_or_raw_body)
           when 404
-            raise Exception::NotFound.new(method, request.url, grac_response.parsed_or_raw_body)
+            raise Exception::NotFound.new(method, response.effective_url, response.parsed_or_raw_body)
           when 409
-            raise Exception::Conflict.new(method, request.url, grac_response.parsed_or_raw_body)
+            raise Exception::Conflict.new(method, response.effective_url, response.parsed_or_raw_body)
           else
-            raise Exception::ServiceError.new(method, request.url, grac_response.parsed_or_raw_body)
+            raise Exception::ServiceError.new(method, response.effective_url, response.parsed_or_raw_body)
         end
       end
   end

--- a/lib/grac/client.rb
+++ b/lib/grac/client.rb
@@ -89,10 +89,10 @@ module Grac
     def build_and_run(method, options = {})
       body   = options[:body].nil? || options[:body].empty? ? nil : options[:body].to_json
       params = @options[:params].merge(options[:params] || {})
-      return wrapped_request.call(@options, uri, method, params, body)
+      return middleware_chain.call(@options, uri, method, params, body)
     end
 
-    def wrapped_request
+    def middleware_chain
       callee = self
 
       @options[:middleware].reverse.each do |mw|

--- a/lib/grac/client.rb
+++ b/lib/grac/client.rb
@@ -114,7 +114,14 @@ module Grac
         caller = self
 
         @options[:middleware].reverse.each do |mw|
-          caller = mw.chain(caller)
+          if mw.kind_of?(Array)
+            middleware_class = mw[0]
+            params           = mw[1..-1]
+
+            caller = middleware_class.new(caller, *params)
+          else
+            caller = mw.new(caller)
+          end
         end
 
         return caller

--- a/lib/grac/client.rb
+++ b/lib/grac/client.rb
@@ -93,20 +93,20 @@ module Grac
     end
 
     def wrapped_request
-      caller = self
+      callee = self
 
       @options[:middleware].reverse.each do |mw|
         if mw.kind_of?(Array)
           middleware_class = mw[0]
           params           = mw[1..-1]
 
-          caller = middleware_class.new(caller, *params)
+          callee = middleware_class.new(callee, *params)
         else
-          caller = mw.new(caller)
+          callee = mw.new(callee)
         end
       end
 
-      return caller
+      return callee
     end
 
     def check_response(method, response)

--- a/lib/grac/response.rb
+++ b/lib/grac/response.rb
@@ -8,9 +8,13 @@ module Grac
     extend Forwardable
 
     def_delegator :@response, :body
+    def_delegator :@response, :code
+    def_delegator :@response, :effective_url
+    def_delegator :@response, :headers
+    def_delegator :@response, :return_message
 
     def initialize(typhoeus_response)
-      @response = typhoeus_response
+      @response    = typhoeus_response
     end
 
     def content_type

--- a/lib/grac/version.rb
+++ b/lib/grac/version.rb
@@ -1,3 +1,3 @@
 module Grac
-  VERSION = "2.1.0"
+  VERSION = "2.1.0-propermiddleware"
 end

--- a/lib/grac/version.rb
+++ b/lib/grac/version.rb
@@ -1,3 +1,3 @@
 module Grac
-  VERSION = "2.1.0-propermiddleware"
+  VERSION = "2.2.0"
 end

--- a/readme.md
+++ b/readme.md
@@ -159,21 +159,26 @@ automatically with each request.
 For this purpose `Proc`s/`lambda`s can be set on the Grac object following the example below:
 
 ```ruby
-mw = lambda do |opts, request_uri, method, params, body|
+mw = lambda do |opts, request_uri, method, params, body, &block|
   # your code here
   # opts        - Hash of the options currently set on the grac object
   # request_uri - uri returned by grac
   # method      - http method (lower case)
   # params      - hash of all params for this request
   # body        - serialized body
-  return opts, request_uri, method, params, body
+  result = block.call(opts, request_uri, method, params, body)
+  # your code for working on the response here
+  return result
 end
 
 Grac::Client.new("http://localhost:80", middleware: [mw])
 ```
 
-Multiple middlewares can be added and they are executed in the order they were added.
+Multiple middlewares can be added and they are wrapped in the order they were added, the first one
+being the first one which is called and the last one to return in the middleware stack.
 The middlware can't modify the original parameters it receives (they're frozen), but it can return new values (or some of the original ones if it only needs to modify some of the parameters). The return values are then passed to the next middleware or, if the middleware is the last one, used for the actual request.
+The request will then return a `Grac::Response` object which can be used to execute some actions after
+the actual request. An example for this is checking a response signature.
 
 ### Response post processing
 

--- a/readme.md
+++ b/readme.md
@@ -159,7 +159,7 @@ automatically with each request.
 For this purpose a class can be added as middleware which accepts at least one parameter during
 initialization and has a call method accepting the parameters as shown in the example below.
 The first parameter will always be the request object, i.e. the instance of `Grac` or another middleware
-already wrapper around it. Additional configuration can be provided to the middleware by accepting
+already wrapped around it. Additional configuration can be provided to the middleware by accepting
 additional parameters. These will be passed along during the request when initializing the middleware.
 
 

--- a/readme.md
+++ b/readme.md
@@ -156,20 +156,18 @@ An example would be an `Authorization` header with a signature depending on host
 While this could be calculated before making the request it is just convenient to have it done
 automatically with each request.
 
-For this purpose an object can be added as middleware which supports the methods `chain` and `call`.
-`chain` is used to chain other middleware down to the actual request. It accepts one parameter which
-should be the `Grac` object or another middleware and it should return itself.
-`call` should accept the parameters as shown in the example below:
+For this purpose a class can be added as middleware which accepts at least one parameter during
+initialization and has a call method accepting the parameters as shown in the example below.
+The first parameter will always be the request object, i.e. the instance of `Grac` or another middleware
+already wrapper around it. Additional configuration can be provided to the middleware by accepting
+additional parameters. These will be passed along during the request when initializing the middleware.
+
 
 ```ruby
 class MW
-  def initialize(options = {})
-    # Use initialize to add any specific configuration
-  end
-
-  def chain(request)
+  def initialize(request, *params)
     @request = request
-    return self
+    @params  = params
   end
 
   def call(opts, request_uri, method, params, body)
@@ -187,7 +185,11 @@ class MW
   end
 end
 
+# Configuring Middleware
 Grac::Client.new("http://localhost:80", middleware: [MW])
+
+# Configuring Middleware with additional parameters
+Grac::Client.new("http://localhost:80", middleware: [[MW, "abc"]])
 ```
 
 Multiple middlewares can be added and they are wrapped in the order they were added, the first one

--- a/readme.md
+++ b/readme.md
@@ -165,9 +165,9 @@ additional parameters. These will be passed along during the request when initia
 
 ```ruby
 class MW
-  def initialize(request, *params)
-    @request = request
-    @params  = params
+  def initialize(request, *settings)
+    @request  = request
+    @settings = settings
   end
 
   def call(opts, request_uri, method, params, body)

--- a/spec/lib/grac/client_spec.rb
+++ b/spec/lib/grac/client_spec.rb
@@ -244,9 +244,9 @@ describe Grac::Client do
     end
   end
 
-  context "wrapped_request" do
+  context "middleware_chain" do
     after do
-      caller = @client.send(:wrapped_request)
+      caller = @client.send(:middleware_chain)
 
       expect(
         ::Typhoeus::Request
@@ -279,34 +279,34 @@ describe Grac::Client do
   end
 
   context "#build_and_run" do
-    it "builds the parameters and passes them to the wrapped_request" do
-      expect(grac).to receive(:wrapped_request).and_return(middleware_stack = double('mw'))
+    it "builds the parameters and passes them to the middleware_chain" do
+      expect(grac).to receive(:middleware_chain).and_return(middleware_stack = double('mw'))
       expect(middleware_stack).to receive(:call).with(
         grac.instance_variable_get(:@options), grac.uri, "get", {}, nil
       ).and_return(1)
       expect(grac.send(:build_and_run, "get", {})).to eq(1)
     end
 
-    it "calls the wrapped_request with a body" do
-      expect(grac).to receive(:wrapped_request).and_return(middleware_stack = double('mw'))
+    it "calls the middleware_chain with a body" do
+      expect(grac).to receive(:middleware_chain).and_return(middleware_stack = double('mw'))
       expect(middleware_stack).to receive(:call).with(
         grac.instance_variable_get(:@options), grac.uri, "get", {}, { data: "asd" }.to_json
       ).and_return(1)
       expect(grac.send(:build_and_run, "get", { :body => { data: "asd" } })).to eq(1)
     end
 
-    it "calls the wrapped_request with a params" do
-      expect(grac).to receive(:wrapped_request).and_return(middleware_stack = double('mw'))
+    it "calls the middleware_chain with a params" do
+      expect(grac).to receive(:middleware_chain).and_return(middleware_stack = double('mw'))
       expect(middleware_stack).to receive(:call).with(
         grac.instance_variable_get(:@options), grac.uri, "get", { data: "asd" }, nil
       ).and_return(1)
       expect(grac.send(:build_and_run, "get", { :params => { data: "asd" } })).to eq(1)
     end
 
-    it "calls the wrapped_request with predefined parameters" do
+    it "calls the middleware_chain with predefined parameters" do
       client = grac.set(params: { "a" => "b" })
 
-      expect(client).to receive(:wrapped_request).and_return(middleware_stack = double('mw'))
+      expect(client).to receive(:middleware_chain).and_return(middleware_stack = double('mw'))
       expect(middleware_stack).to receive(:call).with(
         client.instance_variable_get(:@options), client.uri, "get", { "a" => "b", "c" => "b" }, nil
       ).and_return(1)

--- a/spec/lib/grac/client_spec.rb
+++ b/spec/lib/grac/client_spec.rb
@@ -245,12 +245,9 @@ describe Grac::Client do
   end
 
   context "wrapped_request" do
-    it "wraps all middleware around execute_request" do
-      tmw = TestMiddleware.new
-      client = grac.set(:middleware => [tmw])
-      expect(tmw).to receive(:chain).with(client).and_call_original
-      expect(tmw).to receive(:call).with({}, "http://example.com", "GET", {}, "").and_call_original
-      caller = client.send(:wrapped_request)
+    after do
+      caller = @client.send(:wrapped_request)
+
       expect(
         ::Typhoeus::Request
       ).to receive(:new).with(
@@ -268,6 +265,16 @@ describe Grac::Client do
       allow(response).to receive(:timed_out?).and_return(false)
       response_object = caller.call({}, "http://example.com", "GET", {}, "")
       expect(response_object.class).to eq(::Grac::Response)
+    end
+
+    it "wraps all middleware around execute_request" do
+      @client = grac.set(:middleware => [TestMiddleware])
+      expect(TestMiddleware).to receive(:new).with(@client).and_call_original
+    end
+
+    it "calls the middleware with configuration parameters" do
+      @client = grac.set(:middleware => [[TestMiddleware, "abc", { key: "value"}]])
+      expect(TestMiddleware).to receive(:new).with(@client, "abc", { key: "value" }).and_call_original
     end
   end
 

--- a/spec/lib/grac/response_spec.rb
+++ b/spec/lib/grac/response_spec.rb
@@ -5,11 +5,41 @@ describe Grac::Response do
   let(:typhoeus_response) { double("Typhoeus::Response") }
   let(:content_type)      { 'application/json' }
   let(:body)              { '{"json": "response"}' }
+  let(:code)              { 200 }
+  let(:effective_url)     { "http://example.com" }
+  let(:return_message)    { "Timed out" }
 
   before do
     allow(typhoeus_response).to receive(:headers)
                             .and_return({ 'Content-Type' => content_type })
     allow(typhoeus_response).to receive(:body).and_return(body)
+    allow(typhoeus_response).to receive(:code).and_return(code)
+    allow(typhoeus_response).to receive(:effective_url).and_return(effective_url)
+    allow(typhoeus_response).to receive(:return_message).and_return(return_message)
+  end
+
+  describe '#code' do
+    it "forwards the response code" do
+      expect(response.code).to eq(code)
+    end
+  end
+
+  describe '#effective_url' do
+    it "forwards the effective_url" do
+      expect(response.effective_url).to eq(effective_url)
+    end
+  end
+
+  describe '#headers' do
+    it "forwards the headers" do
+      expect(response.headers).to eq({ 'Content-Type' => content_type })
+    end
+  end
+
+  describe '#return_message' do
+    it "forwards the return_message" do
+      expect(response.return_message).to eq(return_message)
+    end
   end
 
   describe '#json_content?' do

--- a/spec/support/test_middleware.rb
+++ b/spec/support/test_middleware.rb
@@ -1,0 +1,10 @@
+class TestMiddleware
+  def chain(request)
+    @request = request
+    return self
+  end
+
+  def call(opts, request_uri, method, params, body)
+    return @request.call(opts, request_uri, method, params, body)
+  end
+end

--- a/spec/support/test_middleware.rb
+++ b/spec/support/test_middleware.rb
@@ -1,4 +1,9 @@
 class TestMiddleware
+  def initialize(request, *params)
+    @request = request
+    @params  = params
+  end
+
   def chain(request)
     @request = request
     return self


### PR DESCRIPTION
Allows adding middleware which can execute code before and after the request