### PR TITLE
Setting content type header to 'application/json;charset=utf-8' by default

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    grac (2.2.0)
+    grac (2.2.1)
       typhoeus (~> 0.6.9)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,3 @@ DEPENDENCIES
   rake (~> 10.4.1)
   rspec (~> 3.2.0)
   rspec_junit_formatter (~> 0.2.2)
-
-BUNDLED WITH
-   1.10.6

--- a/lib/grac/client.rb
+++ b/lib/grac/client.rb
@@ -17,7 +17,10 @@ module Grac
         :connecttimeout => options[:connecttimeout] || 0.1,
         :timeout        => options[:timeout]        || 15,
         :params         => options[:params]         || {},
-        :headers        => { "User-Agent" => "Grac v#{Grac::VERSION}" }.merge(options[:headers] || {}),
+        :headers        => {
+          "User-Agent"   => "Grac v#{Grac::VERSION}",
+          "Content-Type" => "application/json;charset=utf-8"
+        }.merge(options[:headers] || {}),
         :postprocessing => options[:postprocessing] || {},
         :middleware     => options[:middleware]     || []
       }

--- a/lib/grac/version.rb
+++ b/lib/grac/version.rb
@@ -1,3 +1,3 @@
 module Grac
-  VERSION = "2.2.0"
+  VERSION = "2.2.1"
 end

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ Loading GeoIP information for `github.com`:
 require 'grac'
 # => true
 geoip_client = Grac::Client.new('http://freegeoip.net/json', timeout: 5)
-# => #<Grac::Client:0x000000037f0848 @uri="http://freegeoip.net/json", @options={:connecttimeout=>0.1, :timeout=>15, :params=>{}, :headers=>{"User-Agent"=>"Grac v2.0.0"}, :postprocessing=>{}}>
+# => #<Grac::Client:0x000000037f0848 @uri="http://freegeoip.net/json", @options={:connecttimeout=>0.1, :timeout=>15, :params=>{}, :headers=>{"User-Agent"=>"Grac v2.X.X","Content-Type"=>"application/json;charset=utf-8"}, :postprocessing=>{}}>
 geoip_client.path('/{host}', host: 'github.com').get
 # => {"ip"=>"8.8.8.8", "country_code"=>"US", "country_name"=>"United States", "region_code"=>"CA", "region_name"=>"California", "city"=>"Mountain View", "zip_code"=>"94040", "time_zone"=>"America/Los_Angeles", "latitude"=>37.3845, "longitude"=>-122.0881, "metro_code"=>807}
 ```
@@ -33,7 +33,7 @@ geoip_client.path('/does/not/exist').get
 
 ```ruby
 client = geoip_client.set(postprocessing: { '\A(latitude|longitude)\z' => -> (v) { v.to_i } })
-#  => #<Grac::Client:0x00000003d06378 @uri="http://freegeoip.net/json", @options={:connecttimeout=>0.1, :timeout=>5, :params=>{}, :headers=>{"User-Agent"=>"Grac v2.0.1"}, :postprocessing=>{"\\A(latitude|longitude)\\z"=>#<Proc:0x00000003d06530@(irb):18 (lambda)>}}>
+#  => #<Grac::Client:0x00000003d06378 @uri="http://freegeoip.net/json", @options={:connecttimeout=>0.1, :timeout=>5, :params=>{}, :headers=>{"User-Agent"=>"Grac v2.X.X","Content-Type"=>"application/json;charset=utf-8"}, :postprocessing=>{"\\A(latitude|longitude)\\z"=>#<Proc:0x00000003d06530@(irb):18 (lambda)>}}>
 client.path('/github.com').get
 # => {"ip"=>"192.30.252.128", "country_code"=>"US", "country_name"=>"United States", "region_code"=>"CA", "region_name"=>"California", "city"=>"San Francisco", "zip_code"=>"94107", "time_zone"=>"America/Los_Angeles", "latitude"=>37, "longitude"=>-122, "metro_code"=>807}
 ```
@@ -64,7 +64,7 @@ Available options (shown are the default values):
   connecttimeout: 0.1,  # in seconds
   timeout:        15,   # in seconds
   params:         {},   # default query parameters to be attached to the URL
-  headers:        { "User-Agent" => "Grac v2.X.X" },
+  headers:        { "User-Agent" => "Grac v2.X.X", "Content-Type" => "application/json;charset=utf-8" },
   postprocessing: {},   # see below
   middleware:     []    # see below
 }
@@ -128,7 +128,7 @@ Grac allows you to override options and append to the URI by chaining calls to `
 
 ```ruby
 client = Grac::Client.new("http://localhost:80", timeout: 1)
-# => #<Grac::Client:0x00000003d3dd50 @uri="http://localhost:80", @options={:connecttimeout=>0.1, :timeout=>1, :params=>{}, :headers=>{"User-Agent"=>"Grac v2.0.1"}, :postprocessing=>{}}>
+# => #<Grac::Client:0x00000003d3dd50 @uri="http://localhost:80", @options={:connecttimeout=>0.1, :timeout=>1, :params=>{}, :headers=>{"User-Agent"=>"Grac v2.X.X","Content-Type"=>"application/json;charset=utf-8"}, :postprocessing=>{}}>
 client.set(timeout: 20).path("/v1/users").get(per_page: 1000)
 # => [...]
 ```

--- a/spec/lib/grac/client_spec.rb
+++ b/spec/lib/grac/client_spec.rb
@@ -326,7 +326,7 @@ describe Grac::Client do
     let(:method)            { "GET" }
     let(:response_code)     { 200 }
     let(:return_message)    { nil }
-    let(:response_headers)  { { 'Content-Type' => 'application/json?charset=utf-8' } }
+    let(:response_headers)  { { 'Content-Type' => 'application/json;charset=utf-8' } }
     let(:response_body)     { { "value" => "success" }.to_json }
     let(:typhoeus_response) { double('response', 'effective_url' => grac.uri,
                                      'code' => response_code, 'return_message' => return_message,

--- a/spec/lib/grac/client_spec.rb
+++ b/spec/lib/grac/client_spec.rb
@@ -15,7 +15,10 @@ describe Grac::Client do
         :connecttimeout => 0.1,
         :timeout        => 15,
         :params         => {},
-        :headers        => { "User-Agent" => "Grac v#{Grac::VERSION}" },
+        :headers        => {
+          "User-Agent"   => "Grac v#{Grac::VERSION}",
+          "Content-Type" => "application/json;charset=utf-8"
+        },
         :postprocessing => {},
         :middleware    => []
       })
@@ -26,7 +29,7 @@ describe Grac::Client do
       :connecttimeout => 0.4,
       :timeout        => 10,
       :params         => { "abc" => "def" },
-      :headers        => { "User-Agent" => "Test" },
+      :headers        => { "User-Agent" => "Test", "Content-Type" => "something" },
       :postprocessing => { "amount" => ->(value){ BigDecimal.new(value.to_s) } }
     }.each do |param, value|
       it "allows setting the #{param}" do
@@ -35,10 +38,13 @@ describe Grac::Client do
       end
     end
 
-    it "keeps the user_agent header if it is not overwritten" do
+    it "keeps the user_agent header and content type if it is not overwritten" do
       client = described_class.new("http://localhost", :headers => { "Request-Id" => "123234234" })
-      check_options(client, :headers,
-        { "User-Agent" => "Grac v#{Grac::VERSION}", "Request-Id" => "123234234" })
+      check_options(client, :headers, {
+          "User-Agent" => "Grac v#{Grac::VERSION}",
+          "Content-Type" => "application/json;charset=utf-8",
+          "Request-Id" => "123234234"
+        })
     end
   end
 
@@ -54,7 +60,9 @@ describe Grac::Client do
       a_client = grac.set({ :headers => { "User-Agent" => "123445" } })
       b_client = a_client.set({ :headers => { "Request-Id" => "123445" } })
       check_options(b_client, :headers, {
-        "User-Agent" => "123445", "Request-Id" => "123445"
+        "User-Agent" => "123445",
+        "Content-Type" => "application/json;charset=utf-8",
+        "Request-Id" => "123445"
       })
     end
 
@@ -318,7 +326,7 @@ describe Grac::Client do
     let(:method)            { "GET" }
     let(:response_code)     { 200 }
     let(:return_message)    { nil }
-    let(:response_headers)  { { 'Content-Type' => 'application/json?encoding=utf-8' } }
+    let(:response_headers)  { { 'Content-Type' => 'application/json?charset=utf-8' } }
     let(:response_body)     { { "value" => "success" }.to_json }
     let(:typhoeus_response) { double('response', 'effective_url' => grac.uri,
                                      'code' => response_code, 'return_message' => return_message,


### PR DESCRIPTION
Rack automatically assumes post form and tries to uri decode the body for POST requests.
Since Grac is currently always sending JSON, we should add the content type header so that content containing data not valid as "normal" post data is still accepted.

Other server implementations may have similar problems