### PR TITLE
Escape path parameters to prevent URL injection

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    grac (2.2.1)
+    grac (2.2.2)
       typhoeus (~> 0.6.9)
 
 GEM

--- a/lib/grac/version.rb
+++ b/lib/grac/version.rb
@@ -1,3 +1,3 @@
 module Grac
-  VERSION = "2.2.1"
+  VERSION = "2.2.2"
 end

--- a/readme.md
+++ b/readme.md
@@ -89,13 +89,23 @@ user = client.path("/v1/users").post(name: 'Hans', phone: '12345')
 
 This results in a request to `/v1/users` with the JSON request body `{"name": "Hans", "phone": "12345"}`.
 
-You can optionally pass query parameters:
+You can optionally pass **query parameters**:
 
 ```ruby
 client.path("/v1/users").get(page: '2')
 ```
 
 This results in a request to `/v1/users?page=2`.
+
+You can also provide **path parameters**:
+
+```ruby
+user = client.path("/v1/users/{id}", id: '34').get
+```
+
+This results in a request to `/v1/users/34`.
+
+Both, path and query parameters, are **escaped** using percent-encoding, if necessary. Nevertheless, if your application processes untrusted input, validate that input _before_ using it in your application and passing it to Grac. Escaping parameters is just a mitigation that can prevent URL injection under certain circumstances. Note that this mitigation can only work if you use Grac's parameter functionality, but _can not work_ if you build the URL string yourself.
 
 #### Available request methods
 

--- a/spec/lib/grac/client_spec.rb
+++ b/spec/lib/grac/client_spec.rb
@@ -80,6 +80,14 @@ describe Grac::Client do
       expect(client).to_not eq(grac)
       expect(client.uri).to eq("http://localhost:80/v2/transactions")
     end
+
+    it "escapes path parameters" do
+      # This also checks that spaces are replaced with %20, and _not_ with a plus sign `+`.
+      expect(grac.uri).to eq("http://localhost:80")
+      client = grac.path("/v2/transactions/{id}", id: '../../version# !')
+      expect(client).to_not eq(grac)
+      expect(client.uri).to eq('http://localhost:80/v2/transactions/..%2F..%2Fversion%23%20%21')
+    end
   end
 
   context "http methods" do


### PR DESCRIPTION
Should help as a mitigation if an application doesn’t properly
validate untrusted input and passes it to Grac as path parameter.