### PR TITLE
#13: Use separate exception for non-JSON error responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+## 2.3.0
+
+* Grac now expects error responses to contain JSON and will raise an `ErrorWithInvalidContent` exception if they don't, even if the content type indicates another content type. Success responses with non-JSON content type are still supported. In most cases, that allows making assumptions about the exception's body message. See #13.
+
+## Before 2.3.0
+
+Not available, see commits.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    grac (2.2.2)
+    grac (2.3)
       typhoeus (~> 0.6.9)
 
 GEM
@@ -9,7 +9,7 @@ GEM
   specs:
     builder (3.2.2)
     diff-lcs (1.2.5)
-    ethon (0.8.0)
+    ethon (0.8.1)
       ffi (>= 1.3.0)
     ffi (1.9.10)
     rack (1.6.4)
@@ -45,3 +45,6 @@ DEPENDENCIES
   rake (~> 10.4.1)
   rspec (~> 3.2.0)
   rspec_junit_formatter (~> 0.2.2)
+
+BUNDLED WITH
+   1.13.6

--- a/README.md
+++ b/README.md
@@ -126,11 +126,12 @@ When a **failure** occurs, one of these exceptions will be raised:
 * Status 404: `Grac::Exception::NotFound`
 * Status 409: `Grac::Exception::Conflict`
 * All other status codes: `ServiceError` - this includes all unknown status codes, even 3xx codes. See [issue #4](https://github.com/Barzahlen/grac/issues/4) for ideas on improving this.
-* `InvalidContent` - JSON Parsing failed, server response indicates success
+* `InvalidContent` - JSON parsing for a success status failed, server response indicates success.
+* `ErrorWithInvalidContent` - JSON parsing for an error status failed.
 * `RequestFailed` - The request failed, there's no response from the server.
     * `ServiceTimeout` - A subclass of `RequestFailed` - the request failed due to a timeout (like waiting for the connection or for the response).
 
-See [issue #1](https://github.com/Barzahlen/grac/issues/1) for support for more status codes.
+Responses with error status codes (4xx and 5xx) are expected to have JSON content, regardless of their content type (that's different for success responses). If they don't Grac raises a `ErrorWithInvalidContent` exception. This allows making the assumption when handling a `Grac::ClientException` that the exception's `#body` method contains a parsed JSON response.
 
 ### Chaining
 

--- a/lib/grac.rb
+++ b/lib/grac.rb
@@ -1,2 +1,2 @@
-require 'grac/version'
-require 'grac/client'
+require_relative 'grac/version'
+require_relative 'grac/client'

--- a/lib/grac/exception.rb
+++ b/lib/grac/exception.rb
@@ -70,5 +70,26 @@ module Grac
 
       alias_method :to_s, :message
     end
+
+    class ErrorWithInvalidContent < StandardError
+      def initialize(method, url, status, raw_body, expected_type)
+        @method = (method || "").upcase
+        @url = url
+        @status = status
+        @raw_body = raw_body
+        @expected_type = expected_type
+      end
+
+      def message
+        "#{@method} '#{@url}': Got HTTP #{@status}, failed to parse as '#{@expected_type}'. " \
+        "Raw Body: '#{@raw_body}'"
+      end
+
+      def inspect
+        "#{self.class.name}: #{message}"
+      end
+
+      alias_method :to_s, :message
+    end
   end
 end

--- a/lib/grac/version.rb
+++ b/lib/grac/version.rb
@@ -1,3 +1,3 @@
 module Grac
-  VERSION = "2.2.2"
+  VERSION = "2.3"
 end

--- a/spec/lib/grac/client_spec.rb
+++ b/spec/lib/grac/client_spec.rb
@@ -406,15 +406,16 @@ describe Grac::Client do
         end
       end
 
-      context "plain text" do
-        let(:response_headers) { { "Content-Type" => "text/plain" } }
+      context "HTML response" do
+        let(:response_body) { '<h1>Service unavailable<h1>' }
 
-        it "raises a BadRequest exception" do
+        it 'raises a ErrorWithInvalidContent exception' do
           expect{
             grac.send(:check_response, method, grac_response)
           }.to raise_exception(
-            Grac::Exception::BadRequest,
-            "GET '#{grac.uri}' failed with content: {\"value\":\"success\"}"
+            Grac::Exception::ErrorWithInvalidContent,
+            "GET '#{grac.uri}': Got HTTP 400, failed to parse as 'json'. " \
+            "Raw Body: '<h1>Service unavailable<h1>'"
           )
         end
       end

--- a/spec/lib/grac/exception_spec.rb
+++ b/spec/lib/grac/exception_spec.rb
@@ -82,4 +82,19 @@ describe Grac::Exception::ClientException do
       )
     end
   end
+
+  context "ErrorWithInvalidContent" do
+    it "has a custom message" do
+      exception = Grac::Exception::ErrorWithInvalidContent.new(
+        'put', 'http://example.com', 400, 'any body', 'json'
+      )
+      expect(exception.message).to eq(
+        "PUT 'http://example.com': Got HTTP 400, failed to parse as 'json'. Raw Body: 'any body'"
+      )
+      expect(exception.inspect).to eq(
+        "Grac::Exception::ErrorWithInvalidContent: PUT 'http://example.com': Got HTTP 400, " \
+        "failed to parse as 'json'. Raw Body: 'any body'"
+      )
+    end
+  end
 end


### PR DESCRIPTION
See #13.