### PR TITLE
Check partial responses and raise an exception

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,0 @@
-FROM dreg.barzahlen.de/rubygem:0.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    grac (2.3)
+    grac (2.4.0)
       typhoeus (~> 0.6.9)
 
 GEM

--- a/lib/grac/exception.rb
+++ b/lib/grac/exception.rb
@@ -50,7 +50,13 @@ module Grac
 
     class ServiceTimeout < RequestFailed
       def message
-         "#{@method} '#{@url}' timed out: #{@message}"
+        "#{@method} '#{@url}' timed out: #{@message}"
+      end
+    end
+
+    class PartialResponse < RequestFailed
+      def message
+        "#{@method} '#{@url}' returned an incomplete response body: #{@message}"
       end
     end
 

--- a/lib/grac/version.rb
+++ b/lib/grac/version.rb
@@ -1,3 +1,3 @@
 module Grac
-  VERSION = "2.3.0"
+  VERSION = "2.4.0"
 end

--- a/spec/lib/grac/exception_spec.rb
+++ b/spec/lib/grac/exception_spec.rb
@@ -73,6 +73,15 @@ describe Grac::Exception::ClientException do
     end
   end
 
+  context "PartialResponse" do
+    it "does not parse the body" do
+      exception = Grac::Exception::PartialResponse.new('put', 'http://example.com', 'something<>')
+      expect(exception.message).to eq(
+        "PUT 'http://example.com' returned an incomplete response body: something<>"
+      )
+    end
+  end
+
   context "InvalidContent" do
     it "has a custom message" do
       exception = Grac::Exception::InvalidContent.new('any body', 'json')


### PR DESCRIPTION
We do not want to pass along partial responses to the JSON parser
as this usually results in JSON parser errors due to invalid data.
This adds checking the return_code for :partial_file which indicates
from ethon/libcurl that the Content-Length header does not match the
received response.
Raise an exception if that happens.

We are ignoring other return_codes for now as we do not have the need
to check for them.

Related issue: #12 