### PR TITLE
Reduce amount of strings created on presence check

### DIFF
--- a/lib/grac/client.rb
+++ b/lib/grac/client.rb
@@ -175,7 +175,9 @@ module Grac
         data.each do |key, value|
           processing = nil
           @options[:postprocessing].each do |regex, action|
-            if /#{regex}/ =~ key
+            pattern = Regexp.new(regex).freeze
+
+            if pattern =~ key
               processing = action
             end
           end


### PR DESCRIPTION
Currently a string is interpolated into another string. This is
unnecessary and creates more objects than needed.

We can improve this by creating regex directly from the strings passed
in `[:processing]`.

Here is some benchmarking:

### 3.0.0

```
allocated memory by gem
-----------------------------------
 229871758  grac-3.0.0
 
allocated memory by file
-----------------------------------
 229863258  /usr/local/rvm/gems/ruby-2.1.1/gems/grac-3.0.0/lib/grac/client.rb
  18133936  /usr/local/rvm/gems/ruby-2.1.1/gems/json_pure-1.8.2/lib/json/common.rb
  
allocated memory by location
-----------------------------------
 229853994  /usr/local/rvm/gems/ruby-2.1.1/gems/grac-3.0.0/lib/grac/client.rb:178
  18133696  /usr/local/rvm/gems/ruby-2.1.1/gems/json_pure-1.8.2/lib/json/common.rb:155
  
allocated objects by gem
-----------------------------------
   1260878  grac-3.0.0
   
allocated objects by file
-----------------------------------
   1260817  /usr/local/rvm/gems/ruby-2.1.1/gems/grac-3.0.0/lib/grac/client.rb
    116489  /usr/local/rvm/gems/ruby-2.1.1/gems/json_pure-1.8.2/lib/json/common.rb
    
allocated objects by location
-----------------------------------
   1260745  /usr/local/rvm/gems/ruby-2.1.1/gems/grac-3.0.0/lib/grac/client.rb:178
   
Allocated String Report
-----------------------------------
    224651  "_at$"
    224651  /usr/local/rvm/gems/ruby-2.1.1/gems/grac-3.0.0/lib/grac/client.rb:178

    224651  "_from$"
    224651  /usr/local/rvm/gems/ruby-2.1.1/gems/grac-3.0.0/lib/grac/client.rb:178

    224651  "_to$"
    224651  /usr/local/rvm/gems/ruby-2.1.1/gems/grac-3.0.0/lib/grac/client.rb:178

    224651  "amount$"
    224651  /usr/local/rvm/gems/ruby-2.1.1/gems/grac-3.0.0/lib/grac/client.rb:178

    179736  ""
    179720  /usr/local/rvm/gems/ruby-2.1.1/gems/grac-3.0.0/lib/grac/client.rb:178   
```

### After changes

```
allocated memory by gem
-----------------------------------
 161937727  grac-3.1.0
 
allocated memory by file
-----------------------------------
 161929227  /usr/local/rvm/gems/ruby-2.1.1/gems/grac-3.1.0/lib/grac/client.rb
 
allocated memory by location
-----------------------------------
 130791390  /usr/local/rvm/gems/ruby-2.1.1/gems/grac-3.1.0/lib/grac/client.rb:179
  31128573  /usr/local/rvm/gems/ruby-2.1.1/gems/grac-3.1.0/lib/grac/client.rb:181
  
allocated memory by class
-----------------------------------
  93264683  Regexp
  84195299  String
  
allocated objects by gem
-----------------------------------
    721718  grac-3.1.0
    
allocated objects by file
-----------------------------------
    721657  /usr/local/rvm/gems/ruby-2.1.1/gems/grac-3.1.0/lib/grac/client.rb
    
allocated objects by location
-----------------------------------
    539164  /usr/local/rvm/gems/ruby-2.1.1/gems/grac-3.1.0/lib/grac/client.rb:179
    182421  /usr/local/rvm/gems/ruby-2.1.1/gems/grac-3.1.0/lib/grac/client.rb:181
    
allocated objects by class
-----------------------------------
    665769  String
    179734  Regexp
    
Allocated String Report
-----------------------------------
    134791  "_at$"
     89861  /usr/local/rvm/gems/ruby-2.1.1/gems/grac-3.1.0/lib/grac/client.rb:179
     44930  /usr/local/rvm/gems/ruby-2.1.1/gems/grac-3.1.0/lib/grac/client.rb:181

    134791  "_from$"
     89861  /usr/local/rvm/gems/ruby-2.1.1/gems/grac-3.1.0/lib/grac/client.rb:179
     44930  /usr/local/rvm/gems/ruby-2.1.1/gems/grac-3.1.0/lib/grac/client.rb:181

    134791  "_to$"
     89861  /usr/local/rvm/gems/ruby-2.1.1/gems/grac-3.1.0/lib/grac/client.rb:179
     44930  /usr/local/rvm/gems/ruby-2.1.1/gems/grac-3.1.0/lib/grac/client.rb:181

    134791  "amount$"
     89861  /usr/local/rvm/gems/ruby-2.1.1/gems/grac-3.1.0/lib/grac/client.rb:179
     44930  /usr/local/rvm/gems/ruby-2.1.1/gems/grac-3.1.0/lib/grac/client.rb:181
```

### Amount of calls using something like `get_services`

#### 3.0.0
```
Calculating -------------------------------------
       get_paginated      0.365  (± 0.0%) i/s -     55.000  in 152.615280s
```

#### After changes
```
Calculating -------------------------------------
       get_paginated      0.412  (± 0.0%) i/s -     61.000  in 150.131644s
```