### PR TITLE
Improve `postprocessing` performance by adjusting its logic(around 3.5x faster)

### DIFF
--- a/spec/lib/grac/client_spec.rb
+++ b/spec/lib/grac/client_spec.rb
@@ -34,6 +34,11 @@ describe Grac::Client do
     }.each do |param, value|
       it "allows setting the #{param}" do
         client = described_class.new("http://localhost:80", param => value)
+
+        if param == :postprocessing
+          (value, key) = *(value).flatten
+          value = Hash[Regexp.new(value), key]
+        end
         check_options(client, param, value)
       end
     end


### PR DESCRIPTION
Inside client#postprocessing https://github.com/Barzahlen/grac/blob/master/lib/grac/client.rb#L177 we go through each data key and compare it to each and every key present on @options[:postprocessing], even if there was already a successful match to pick the lambda to run, we continue making comparisons which is useless, since no other will match and because of this wastes time.

I propose that we stop looping on @options[:postprocessing] on 1st match, pick the lambda and continue processing data.

In my initial tests i've seen this makes the method around 3.5-4 times faster.