### PR TITLE
Prepare request body based on content type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.0
+
+* Encode request bodies based on the configured request `Content-Type`
+
 ## 3.2.0
 
 * Improve JSON parsing performance by using [oj](https://github.com/ohler55/oj) gem instead of the builtin `json` library

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    grac (3.2.0)
+    grac (3.3.0)
       oj (~> 3.6.13)
       typhoeus (~> 1)
 
@@ -11,9 +11,9 @@ GEM
     benchmark-ips (2.7.2)
     builder (3.2.3)
     diff-lcs (1.3)
-    ethon (0.11.0)
+    ethon (0.12.0)
       ffi (>= 1.3.0)
-    ffi (1.9.25)
+    ffi (1.10.0)
     oj (3.6.13)
     rack (1.6.11)
     rack-test (0.6.3)
@@ -32,7 +32,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    typhoeus (1.3.0)
+    typhoeus (1.3.1)
       ethon (>= 0.9.0)
 
 PLATFORMS
@@ -48,4 +48,4 @@ DEPENDENCIES
   rspec (~> 3.8)
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Cash Payment Solutions GmbH
+Copyright (c) 2019 Cash Payment Solutions GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -115,6 +115,13 @@ Both, path and query parameters, are **escaped** using percent-encoding, if nece
 * `put(request_body, query_params)`
 * `patch(request_body, query_params)`
 
+#### Body encoding
+
+`POST`, `PUT`, and `PATCH` allow passing a request body.
+The request body will be automatically encoded based on the configured `Content-Type` request header.
+The default for this header is set to `application/json;charset=utf-8`, which results in request bodies being encoded as JSON by default.
+The `Content-Type` `application/x-www-form-urlencoded` is also specifically handled. `grac` will not encode the body and instead relies on the default behaviour provided by `Typhoeus`. Other unhandled `Content-Type`s will result in the same behaviour, allowing to use `grac` also for use cases that do not require JSON bodies.
+
 #### Responses
 
 For most **success** status codes (`2xx`, except `204` and `205`), Grac tries to parse the response as JSON if the response Content-Type contains `application/json`. For other content types, Grac returns the response as String and doesn't attempt to parse it. For a `204` or `205` response, the return value is undefined (it's currently `true`, but this might change in the future).

--- a/lib/grac/version.rb
+++ b/lib/grac/version.rb
@@ -1,3 +1,3 @@
 module Grac
-  VERSION = "3.2.0"
+  VERSION = "3.3.0"
 end


### PR DESCRIPTION
If we set a request body which is actually not JSON, but we want to send along a body, it isn't very intuitive that we encode the body as JSON regardless.
While JSON can be a good default, other cases should also be supported.