### PR TITLE
Use Regex#match? instead of Regex#=~

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.1.1
-  - 2.5.1
+  - 2.5.3
 script:
   - bundle exec rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    grac (3.3.0)
+    grac (4.0.0)
       oj (~> 3.6.13)
       typhoeus (~> 1)
 

--- a/grac.gemspec
+++ b/grac.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
+  spec.required_ruby_version = '~> 2.4'
 
   spec.add_development_dependency "rake",          "~> 12.3"
   spec.add_development_dependency "rspec",         "~> 3.8"

--- a/lib/grac/client.rb
+++ b/lib/grac/client.rb
@@ -210,7 +210,7 @@ module Grac
       if data.kind_of?(Hash)
         data.each do |key, value|
           processing = nil
-          regexp = @options[:postprocessing].keys.detect { |pattern| pattern =~ key }
+          regexp = @options[:postprocessing].keys.detect { |pattern| pattern.match?(key) }
 
           if !regexp.nil?
             processing = @options[:postprocessing][regexp]

--- a/lib/grac/version.rb
+++ b/lib/grac/version.rb
@@ -1,3 +1,3 @@
 module Grac
-  VERSION = "3.3.0"
+  VERSION = "4.0.0"
 end


### PR DESCRIPTION
Ruby 2.4 adds a new Regexp#match? method for regular expressions which is
three times faster than any Regexp method in Ruby 2.3.

Some examples: https://gist.github.com/danroux/2664cd0f3d7ac70ad0a44affc2fc7c35

```
Warming up --------------------------------------
       Regexp#match?    42.612k i/100ms
        Regexp#match    24.297k i/100ms
           Regexp#=~    29.298k i/100ms
          Regexp#===    29.125k i/100ms
Calculating -------------------------------------
       Regexp#match?      1.980M (± 9.3%) i/s -      9.801M in   5.009747s
        Regexp#match    504.614k (±12.5%) i/s -      2.478M in   5.043453s
           Regexp#=~    721.769k (±10.7%) i/s -      3.574M in   5.029033s
          Regexp#===    725.898k (± 9.3%) i/s -      3.612M in   5.027724s

Comparison:
       Regexp#match?:  1979967.5 i/s
          Regexp#===:   725897.6 i/s - 2.73x  slower
           Regexp#=~:   721769.2 i/s - 2.74x  slower
```